### PR TITLE
Add timeline range support to keyframe selectors

### DIFF
--- a/src/css.grammar
+++ b/src/css.grammar
@@ -49,8 +49,16 @@ KeyframesStatement {
   KeyframeList
 }
 
+timelineRangeName {
+  kw<"cover"> | kw<"contain"> | kw<"entry"> | kw<"exit"> | kw<"entry-crossing"> | kw<"exit-crossing">
+}
+
+keyframeSelector {
+  kw<"from"> | kw<"to"> | NumberLiteral | timelineRangeName NumberLiteral
+}
+
 KeyframeList {
-  "{" ((kw<"from"> | kw<"to"> | NumberLiteral) Block)* "}"
+  "{" (keyframeSelector ("," keyframeSelector)* Block)* "}"
 }
 
 SupportsStatement {

--- a/test/statements.txt
+++ b/test/statements.txt
@@ -63,6 +63,51 @@ StyleSheet(KeyframesStatement(keyframes,KeyframeName,KeyframeList(
   Comment,
   to,Block(Declaration(PropertyName,NumberLiteral(Unit))))))
 
+# Multiple keyframe selectors
+
+@keyframes anim-1 {
+  0% { margin-top: 0px; }
+  25%, 50%  { margin-top: 50px; }
+  40% { margin-top: 25px; }
+}
+
+==>
+
+StyleSheet(KeyframesStatement(keyframes,KeyframeName,KeyframeList(
+  NumberLiteral(Unit),Block(Declaration(PropertyName,NumberLiteral(Unit))),
+  NumberLiteral(Unit), NumberLiteral(Unit), Block(Declaration(PropertyName,NumberLiteral(Unit))),
+  NumberLiteral(Unit),Block(Declaration(PropertyName,NumberLiteral(Unit))))))
+
+# Keyframes statements with range
+
+@keyframes anim-1 {
+  entry 0%  { margin-top: 50px; }
+  entry 100%  { margin-top: 50px; }
+  exit 0% { margin-top: 50px; }
+  exit 100% { margin-top: 50px; }
+}
+
+==>
+
+StyleSheet(KeyframesStatement(keyframes,KeyframeName,KeyframeList(
+  entry, NumberLiteral(Unit),Block(Declaration(PropertyName,NumberLiteral(Unit))),
+  entry, NumberLiteral(Unit),Block(Declaration(PropertyName,NumberLiteral(Unit))),
+  exit, NumberLiteral(Unit),Block(Declaration(PropertyName,NumberLiteral(Unit))),
+  exit, NumberLiteral(Unit),Block(Declaration(PropertyName,NumberLiteral(Unit))))))
+
+# Keyframes statements with range and multiple keyframe selectors
+
+@keyframes fade-in-out-animation {
+  entry 0%, exit 100% { opacity: 0 }
+  entry 100%, exit 0% { opacity: 1 }
+}
+
+==>
+
+StyleSheet(KeyframesStatement(keyframes,KeyframeName,KeyframeList(
+  entry, NumberLiteral(Unit), exit, NumberLiteral(Unit), Block(Declaration(PropertyName,NumberLiteral)),
+  entry, NumberLiteral(Unit), exit, NumberLiteral(Unit), Block(Declaration(PropertyName,NumberLiteral)))))
+
 # Media statements
 
 @media screen and (min-width: 30em) and (orientation: landscape) {}


### PR DESCRIPTION
This is being introduced with scroll animations[1]

Drive by fix: a keyframe block might contain multiple keyframe selectors according to here[2]

[1]: https://www.w3.org/TR/scroll-animations-1/#named-range-keyframes
[2]: https://www.w3.org/TR/css-animations-1/#keyframes