### PR TITLE
Range Queries (`@media (width >= 30em) {}`)

### DIFF
--- a/src/css.grammar
+++ b/src/css.grammar
@@ -107,7 +107,15 @@ query {
   BinaryQuery { query !valueOp LogicOp query } |
   UnaryQuery { @specialize[@name=UnaryQueryOp]<identifier, "not" | "only"> query } |
   ParenthesizedQuery { "(" query ")" } |
-  SelectorQuery { @specialize[@name=selector]<callee, "selector"> "(" selector ")" }
+  SelectorQuery { @specialize[@name=selector]<callee, "selector"> "(" selector ")" } |
+  RangeQuery {
+    "(" 
+    (FeatureName { identifier } | NumberLiteral) !valueOp 
+    RangeOp
+    (FeatureName { identifier } | NumberLiteral)
+    (RangeOp (FeatureName { identifier } | NumberLiteral))?
+    ")"
+  }
 }
 
 value {
@@ -172,6 +180,8 @@ commaSep<value> { "" | value ("," value?)* }
   SiblingOp { "~" | "+" }
 
   LogicOp { "and" | "or" }
+
+  RangeOp { ">=" | ">" | "<" | "<="}
 
   BinOp { $[+\-*/] }
 

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -20,7 +20,7 @@ export const cssHighlighting = styleTags({
   Callee: t.operatorKeyword,
   Unit: t.unit,
   "UniversalSelector NestingSelector": t.definitionOperator,
-  MatchOp: t.compareOperator,
+  "MatchOp RangeOp": t.compareOperator,
   "ChildOp SiblingOp, LogicOp": t.logicOperator,
   BinOp: t.arithmeticOperator,
   Important: t.modifier,

--- a/test/statements.txt
+++ b/test/statements.txt
@@ -102,6 +102,7 @@ StyleSheet(KeyframesStatement(keyframes,KeyframeName,KeyframeList(
 @media (min-height: 680px), screen and (orientation: portrait) {}
 @media not all and (monochrome) {}
 @media only screen {}
+@media (10em <= width < 30em) {}
 
 ==>
 
@@ -110,7 +111,8 @@ StyleSheet(
     FeatureQuery(FeatureName,ValueName)),Block),
   MediaStatement(media,FeatureQuery(FeatureName,NumberLiteral(Unit)),BinaryQuery(KeywordQuery,LogicOp,FeatureQuery(FeatureName,ValueName)),Block),
   MediaStatement(media,UnaryQuery(UnaryQueryOp,BinaryQuery(KeywordQuery,LogicOp,ParenthesizedQuery(KeywordQuery))),Block),
-  MediaStatement(media,UnaryQuery(UnaryQueryOp,KeywordQuery),Block))
+  MediaStatement(media,UnaryQuery(UnaryQueryOp,KeywordQuery),Block)
+  MediaStatement(media,RangeQuery(NumberLiteral(Unit),RangeOp,FeatureName,RangeOp,NumberLiteral(Unit)),Block))
 
 # Supports statements
 


### PR DESCRIPTION
Add support for https://www.w3.org/TR/mediaqueries-4/#mq-range-context 

It technically allows invalid syntax, as `(width > 300px > width)` should be an invalid query, but I'm guessing the added complexity isn't worth it. If you want that I can add it anyway!