### PR TITLE
Relative selectors `parent { > child { } }`

### DIFF
--- a/src/css.grammar
+++ b/src/css.grammar
@@ -81,9 +81,9 @@ selector {
   } |
   IdSelector { selector? !attribute "#" IdName { identifier } } |
   AttributeSelector { selector? !attribute "[" AttributeName { identifier } (MatchOp value)? "]" } |
-  ChildSelector { selector !structure ChildOp selector } |
+  ChildSelector { selector? !structure ChildOp selector } |
   DescendantSelector { selector !structure descendantOp selector } |
-  SiblingSelector { selector !structure SiblingOp selector }
+  SiblingSelector { selector? !structure SiblingOp selector }
 }
 
 pseudoClassWithArg {

--- a/test/selector.txt
+++ b/test/selector.txt
@@ -109,6 +109,21 @@ StyleSheet(RuleSet(TagSelector(TagName),Block(
   RuleSet(DescendantSelector(TagSelector(TagName), NestingSelector),Block),
   RuleSet(ChildSelector(NestingSelector,ChildOp,TagSelector(TagName)),Block))))
 
+# Relative selectors
+
+a {
+  p {}
+  > f {}
+  + g {}
+}
+
+==>
+
+StyleSheet(RuleSet(TagSelector(TagName),Block(
+  RuleSet(TagSelector(TagName),Block),
+  RuleSet(ChildSelector(ChildOp,TagSelector(TagName)),Block),
+  RuleSet(SiblingSelector(SiblingOp,TagSelector(TagName)),Block))))
+
 # Sibling selectors
 
 a.b ~ c.d {}


### PR DESCRIPTION
Add support for https://drafts.csswg.org/selectors-4/#relative

Initially I added a RelativeSelector rule, but figured it would be easier to just make the first selectors optional.

This does lead to top level relative selectors, which are normally invalid,
and to multiple child nested selectors parsing. (`> > uhh { }`)