### PR TITLE
Update min version of @lezer/lr dependency to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@lezer/common": "^1.2.0",
-    "@lezer/lr": "^1.0.0",
+    "@lezer/lr": "^1.3.0",
     "@lezer/highlight": "^1.0.0"
   },
   "repository": {


### PR DESCRIPTION
This parser makes use of the "local token group" feature, which was added to @lezer/lr in version 1.3.0. Using an earlier version (as allowed by the semver range) doesn't work.

I used the "edit file" functionality in GitHub to make this change, please let me know if there is anything else I should do to contribute to this repo.